### PR TITLE
fix: MIME text_plain duplicate deleted

### DIFF
--- a/nginx_extra.conf
+++ b/nginx_extra.conf
@@ -2,4 +2,4 @@ gzip on;
 gzip_vary on;
 gzip_comp_level 6;
 gzip_buffers 4 32k;
-gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/x-font-ttf application/javascript font/eot font/opentype image/svg+xml image/x-icon text/plain;
+gzip_types text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/x-font-ttf application/javascript font/eot font/opentype image/svg+xml image/x-icon text/plain;


### PR DESCRIPTION
Fix the following warnings:
nginx: [warn] duplicate MIME type "text/plain" in metwork/mfserv/tmp/config_auto/nginx.conf:305
